### PR TITLE
Fix icon sprite generation to support subdirectories in IDs

### DIFF
--- a/generate_icon_list.js
+++ b/generate_icon_list.js
@@ -120,9 +120,10 @@ function buildSpriteContent(sourceDir) {
   }
 
   const symbols = iconFiles.map((file) => {
-    const id = path
-      .basename(file)
+    const relativePath = path.relative(sourceDir, file);
+    const id = relativePath
       .replace(/\.svg(\.gz)?$/i, "")
+      .replace(/[\\/]/g, "_")
       .replace(/[^a-z0-9_-]/gi, "_");
 
     let svgContent = fs.readFileSync(file);


### PR DESCRIPTION
## fix icon sprite generation
added code to correctly handle icons in subdirs correctly so the svgIcon.vue component will pick them up