### PR TITLE
unify progress indicators, fix startup performance and data correctness

### DIFF
--- a/src/boot/registerSvgIcon.js
+++ b/src/boot/registerSvgIcon.js
@@ -1,9 +1,11 @@
 import { boot } from "quasar/wrappers";
 import svgIcon from "src/components/svgIcon.vue";
 import mySelect from "src/components/mySelect.vue";
+import ControllerProgressDisplay from "src/components/Dialogs/ControllerProgressDisplay.vue";
 
 export default boot(({ app }) => {
   // Register components globally
   app.component("svgIcon", svgIcon);
   app.component("mySelect", mySelect);
+  app.component("ControllerProgressDisplay", ControllerProgressDisplay);
 });

--- a/src/components/Dialogs/ControllerProgressDisplay.vue
+++ b/src/components/Dialogs/ControllerProgressDisplay.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="text-center q-pa-lg">
+    <div class="text-h6 q-mb-md">{{ title }}</div>
+    <q-circular-progress
+      v-if="progress.total === 0"
+      indeterminate
+      size="80px"
+      :thickness="0.15"
+      :color="color"
+      class="q-mb-md"
+    />
+    <q-circular-progress
+      v-else
+      :value="(progress.completed / progress.total) * 100"
+      size="80px"
+      :thickness="0.15"
+      :color="color"
+      track-color="grey-3"
+      class="q-mb-md"
+    />
+    <div class="text-subtitle2 q-mb-xs">
+      <slot name="status">
+        <span v-if="progress.total === 0">Preparing...</span>
+        <span v-else
+          >{{ progress.completed }} / {{ progress.total }} controllers
+          updated</span
+        >
+      </slot>
+    </div>
+    <div v-if="$slots.detail || subtitle" class="text-caption text-grey-6">
+      <slot name="detail">{{ subtitle }}</slot>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "ControllerProgressDisplay",
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    progress: {
+      type: Object,
+      required: true,
+    },
+    color: {
+      type: String,
+      default: "primary",
+    },
+    subtitle: {
+      type: String,
+      default: null,
+    },
+  },
+};
+</script>

--- a/src/components/Dialogs/addPresetDialog.vue
+++ b/src/components/Dialogs/addPresetDialog.vue
@@ -27,25 +27,24 @@
         />
       </q-card-section>
 
-      <q-card-section v-if="isSaving || isRollingBack">
-        <q-linear-progress
-          :value="progressValue"
-          :color="isRollingBack ? 'negative' : 'primary'"
-          size="md"
-          :indeterminate="progress.total === 0"
-        />
-        <div class="text-center q-mt-sm">
-          <span v-if="!isRollingBack">
-            {{ progress.completed }} of {{ progress.total }} controllers updated
-          </span>
-          <span v-else>
-            {{
-              progress.message ||
-              `${progress.completed} of ${progress.total} controllers rolled back`
-            }}
-          </span>
-        </div>
-      </q-card-section>
+      <ControllerProgressDisplay
+        v-if="isSaving || isRollingBack"
+        :title="isRollingBack ? 'Rolling Back...' : 'Saving Preset'"
+        :progress="progress"
+        :color="isRollingBack ? 'negative' : 'primary'"
+      >
+        <template #status>
+          <span v-if="!isRollingBack && progress.total === 0">Preparing...</span>
+          <span v-else-if="!isRollingBack"
+            >{{ progress.completed }} of {{ progress.total }} controllers
+            updated</span
+          >
+          <span v-else>{{
+            progress.message ||
+            `${progress.completed} of ${progress.total} controllers rolled back`
+          }}</span>
+        </template>
+      </ControllerProgressDisplay>
       <q-card-section v-if="isAborting && !isRollingBack && progress.message">
         <div class="text-center q-pa-md">
           <svgIcon name="info" size="2rem" class="text-primary" />

--- a/src/components/Dialogs/deleteAllPresetsDialog.vue
+++ b/src/components/Dialogs/deleteAllPresetsDialog.vue
@@ -22,29 +22,22 @@
           <q-toolbar-title>Deleting All Presets...</q-toolbar-title>
         </q-toolbar>
 
-        <q-card-section>
-          <div class="text-center q-mb-md">
-            <p>Deleting all presets from all controllers</p>
-          </div>
-
-          <q-linear-progress
-            :value="progressValue"
-            color="negative"
-            size="md"
-            :indeterminate="currentStage === 'fetching'"
-          />
-          <div class="text-center q-mt-sm">
-            <div v-if="currentStage === 'fetching'">
-              Retrieving presets from controllers...
-            </div>
-            <div v-else-if="currentStage === 'deleting'">
-              {{ progress.completed }} of {{ progress.total }} presets deleted
-            </div>
-            <div v-else-if="currentStage === 'complete'">
-              Deletion complete!
-            </div>
-          </div>
-        </q-card-section>
+        <ControllerProgressDisplay
+          title="Deleting All Presets"
+          :progress="progress"
+          color="negative"
+        >
+          <template #status>
+            <span v-if="currentStage === 'fetching'"
+              >Retrieving presets from controllers...</span
+            >
+            <span v-else-if="currentStage === 'deleting'"
+              >{{ progress.completed }} of {{ progress.total }} presets
+              deleted</span
+            >
+            <span v-else-if="currentStage === 'complete'">Deletion complete!</span>
+          </template>
+        </ControllerProgressDisplay>
       </template>
 
       <!-- Buttons - different based on mode -->
@@ -74,6 +67,7 @@ import { ref, computed } from "vue";
 import { useDialogPluginComponent } from "quasar";
 import { useAppDataStore } from "src/stores/appDataStore";
 import { useControllersStore } from "src/stores/controllersStore";
+import { createAbortTimeout } from "src/services/tools";
 
 export default {
   name: "deleteAllPresetsDialog",
@@ -106,9 +100,16 @@ export default {
         const allControllerPresets = {};
         for (const controller of controllers.data) {
           try {
+            const readAbort = createAbortTimeout(5000, () => {
+              console.warn(
+                `Timeout fetching presets from ${controller.ip_address} (5s)`,
+              );
+            });
             const response = await fetch(
               `http://${controller.ip_address}/data`,
+              { signal: readAbort.signal },
             );
+            readAbort.clear();
             if (response.ok) {
               const data = await response.json();
               if (data.presets && Array.isArray(data.presets)) {
@@ -139,13 +140,18 @@ export default {
           for (const preset of allControllerPresets[ip]) {
             try {
               let payload = { [`presets[id=${preset.id}]`]: [] };
+              const writeAbort = createAbortTimeout(5000, () => {
+                console.warn(`Timeout deleting preset from ${ip} (5s)`);
+              });
               await fetch(`http://${ip}/data`, {
                 method: "POST",
                 headers: {
                   "Content-Type": "application/json",
                 },
                 body: JSON.stringify(payload),
+                signal: writeAbort.signal,
               });
+              writeAbort.clear();
 
               // Update progress
               progress.value.completed++;

--- a/src/components/Dialogs/deleteItemDialog.vue
+++ b/src/components/Dialogs/deleteItemDialog.vue
@@ -32,35 +32,16 @@
 
       <!-- Progress mode with modal circular progress -->
       <template v-else>
-        <q-card-section class="text-center q-pa-lg">
-          <div class="text-h6 q-mb-md">Deleting {{ itemTypeCapitalized }}</div>
-          <q-circular-progress
-            v-if="progress.total === 0"
-            indeterminate
-            size="80px"
-            :thickness="0.15"
-            color="negative"
-            class="q-mb-md"
-          />
-          <q-circular-progress
-            v-else
-            :value="(progress.completed / progress.total) * 100"
-            size="80px"
-            :thickness="0.15"
-            color="negative"
-            track-color="grey-3"
-            class="q-mb-md"
-          />
-          <div v-if="progress.total === 0" class="text-subtitle2 q-mb-xs">
-            Preparing to delete...
-          </div>
-          <div v-else class="text-subtitle2 q-mb-xs">
-            {{ progress.completed }} / {{ progress.total }} controllers updated
-          </div>
-          <div class="text-caption text-grey-6">
-            Please wait while "{{ item.name }}" is being deleted...
-          </div>
-        </q-card-section>
+        <ControllerProgressDisplay
+          :title="'Deleting ' + itemTypeCapitalized"
+          :progress="progress"
+          color="negative"
+        >
+          <template #detail
+            >Please wait while "{{ item.name }}" is being
+            deleted...</template
+          >
+        </ControllerProgressDisplay>
       </template>
 
       <!-- Buttons - different based on mode -->

--- a/src/components/Dialogs/groupDialog.vue
+++ b/src/components/Dialogs/groupDialog.vue
@@ -64,35 +64,11 @@
     position="standard"
   >
     <q-card class="progress-modal-card">
-      <q-card-section class="text-center q-pa-lg">
-        <div class="text-h6 q-mb-md">Saving Group</div>
-        <q-circular-progress
-          v-if="progress.total === 0"
-          indeterminate
-          size="80px"
-          :thickness="0.15"
-          color="primary"
-          class="q-mb-md"
-        />
-        <q-circular-progress
-          v-else
-          :value="(progress.completed / progress.total) * 100"
-          size="80px"
-          :thickness="0.15"
-          color="primary"
-          track-color="grey-3"
-          class="q-mb-md"
-        />
-        <div v-if="progress.total === 0" class="text-subtitle2 q-mb-xs">
-          Preparing to save...
-        </div>
-        <div v-else class="text-subtitle2 q-mb-xs">
-          {{ progress.completed }} / {{ progress.total }} controllers updated
-        </div>
-        <div class="text-caption text-grey-6">
-          Please wait while the group is being saved...
-        </div>
-      </q-card-section>
+      <ControllerProgressDisplay
+        title="Saving Group"
+        :progress="progress"
+        subtitle="Please wait while the group is being saved..."
+      />
     </q-card>
   </q-dialog>
 </template>

--- a/src/components/Dialogs/sceneDialog.vue
+++ b/src/components/Dialogs/sceneDialog.vue
@@ -125,36 +125,11 @@
         position="standard"
       >
         <q-card class="progress-modal-card">
-          <q-card-section class="text-center q-pa-lg">
-            <div class="text-h6 q-mb-md">Saving Scene</div>
-            <q-circular-progress
-              v-if="progress.total === 0"
-              indeterminate
-              size="80px"
-              :thickness="0.15"
-              color="primary"
-              class="q-mb-md"
-            />
-            <q-circular-progress
-              v-else
-              :value="(progress.completed / progress.total) * 100"
-              size="80px"
-              :thickness="0.15"
-              color="primary"
-              track-color="grey-3"
-              class="q-mb-md"
-            />
-            <div v-if="progress.total === 0" class="text-subtitle2 q-mb-xs">
-              Preparing to save...
-            </div>
-            <div v-else class="text-subtitle2 q-mb-xs">
-              {{ progress.completed }} / {{ progress.total }} controllers
-              updated
-            </div>
-            <div class="text-caption text-grey-6">
-              Please wait while the scene is being saved...
-            </div>
-          </q-card-section>
+          <ControllerProgressDisplay
+            title="Saving Scene"
+            :progress="progress"
+            subtitle="Please wait while the scene is being saved..."
+          />
         </q-card>
       </q-dialog>
 

--- a/src/components/cards/colorPickerSections/HsvSection.vue
+++ b/src/components/cards/colorPickerSections/HsvSection.vue
@@ -107,7 +107,7 @@ export default {
           ? options[colorModelIndex]
           : options[0];
 
-      return currentMode === "RGBWW";
+      return currentMode === "RGBWW" || currentMode === "RGBWWCW" || currentMode === "RGBCW";
     });
 
     // Flag to prevent emitting during prop updates from websocket events

--- a/src/services/initializeStores.js
+++ b/src/services/initializeStores.js
@@ -9,9 +9,9 @@ import useWebSocket from "src/services/websocket.js";
 
 const INIT_DELAYS = {
   controllers: 0,
-  websocket: 300,
-  storeStart: 500,
-  betweenStores: 100,
+  websocket: 0,
+  storeStart: 0,
+  betweenStores: 0,
   sync: 0,
 };
 
@@ -142,14 +142,14 @@ export default async function initializeStores(options = {}) {
       },
     ];
 
-    for (const step of storeSteps) {
-      if (isStale()) {
-        return;
-      }
+    if (isStale()) {
+      return;
+    }
 
-      const shouldFetch = force || storeCacheKeys[step.key] !== controllerKey;
-
-      if (shouldFetch) {
+    await Promise.all(
+      storeSteps.map(async (step) => {
+        const shouldFetch = force || storeCacheKeys[step.key] !== controllerKey;
+        if (!shouldFetch) return;
         try {
           await step.fetch();
           if (step.store.status === storeStatus.READY) {
@@ -158,14 +158,10 @@ export default async function initializeStores(options = {}) {
         } catch (error) {
           console.error(`Failed to initialize ${step.key} store:`, error);
         }
-      }
+      }),
+    );
 
-      if (!(await safeDelay(INIT_DELAYS.betweenStores))) {
-        return;
-      }
-    }
-
-    if (!(await safeDelay(INIT_DELAYS.sync))) {
+    if (isStale()) {
       return;
     }
 

--- a/src/services/saveDelete.js
+++ b/src/services/saveDelete.js
@@ -1,5 +1,5 @@
 import { useControllersStore } from "src/stores/controllersStore";
-import { makeID } from "src/services/tools";
+import { makeID, createAbortTimeout } from "src/services/tools";
 
 /**
  * Generic function to save any item type (preset, group, scene)
@@ -55,9 +55,12 @@ export async function saveItem(
       }
 
       // Get existing data from controller
+      const readAbort = createAbortTimeout(5000);
       const existingDataResponse = await fetch(
         `http://${controller.ip_address}/data`,
+        { signal: readAbort.signal },
       );
+      readAbort.clear();
       const existingData = await existingDataResponse.json();
       const existingItem = existingData[pluralType].find(
         (i) => i.id === item.id,
@@ -74,13 +77,16 @@ export async function saveItem(
 
       // Only send if it's new or newer
       if (!existingItem || existingItem.ts < item.ts) {
+        const writeAbort = createAbortTimeout(5000);
         const response = await fetch(`http://${controller.ip_address}/data`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
           },
           body: JSON.stringify(payload),
+          signal: writeAbort.signal,
         });
+        writeAbort.clear();
 
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);

--- a/src/services/tools.js
+++ b/src/services/tools.js
@@ -113,7 +113,7 @@ export async function getModifyPost(ipAddress, modifyFn, timeoutMs = 8000) {
 
 function makeID() {
   const infoData = infoDataStore();
-  const controllerID = infoData.data.deviceid;
+  const controllerID = infoData.data?.device?.deviceid ?? infoData.data?.deviceid;
 
   const localID = getLocalID(8);
   return `${controllerID}-${localID}`;

--- a/src/stores/appDataStore.js
+++ b/src/stores/appDataStore.js
@@ -468,14 +468,21 @@ export const useAppDataStore = defineStore("appData", {
 
           try {
             // Wrap each controller request in its own try/catch
+            const abort = createAbortTimeout(5000, () => {
+              console.warn(
+                `Timeout deleting preset from ${controller.ip_address} (5s)`,
+              );
+            });
             const response = await fetch(
               `http://${controller.ip_address}/data`,
               {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(payload),
+                signal: abort.signal,
               },
             );
+            abort.clear();
 
             if (!response.ok) {
               const errorText = await response.text();
@@ -1021,6 +1028,11 @@ export const useAppDataStore = defineStore("appData", {
           // Check if the controller already has this metadata
           let existingMetadata = null;
           try {
+            const readAbort = createAbortTimeout(5000, () => {
+              console.warn(
+                `Timeout reading metadata from ${controller.name || controller.hostname} (5s)`,
+              );
+            });
             const response = await fetch(
               `http://${controller.ip_address}/data`,
               {
@@ -1028,8 +1040,10 @@ export const useAppDataStore = defineStore("appData", {
                 headers: {
                   "Content-Type": "application/json",
                 },
+                signal: readAbort.signal,
               },
             );
+            readAbort.clear();
 
             if (response.ok) {
               const data = await response.json();
@@ -1074,6 +1088,11 @@ export const useAppDataStore = defineStore("appData", {
             );
 
             try {
+              const writeAbort = createAbortTimeout(5000, () => {
+                console.warn(
+                  `Timeout saving metadata to ${controller.name || controller.hostname} (5s)`,
+                );
+              });
               const response = await fetch(
                 `http://${controller.ip_address}/data`,
                 {
@@ -1082,8 +1101,10 @@ export const useAppDataStore = defineStore("appData", {
                     "Content-Type": "application/json",
                   },
                   body: JSON.stringify(payload),
+                  signal: writeAbort.signal,
                 },
               );
+              writeAbort.clear();
 
               if (!response.ok) {
                 console.error(


### PR DESCRIPTION
Changes
d1e46cf — refactor: unify progress indicators and add 5s controller timeout
New component: ControllerProgressDisplay.vue — a shared progress indicator replacing the inconsistent mix of q-circular-progress and q-linear-progress used across save/delete dialogs. Registered globally in registerSvgIcon.js.
Updated dialogs: sceneDialog.vue, groupDialog.vue, deleteItemDialog.vue, addPresetDialog.vue, deleteAllPresetsDialog.vue — all now use <ControllerProgressDisplay> with title, progress, color, and slot props for status text.
5-second timeout: Added createAbortTimeout(5000) to the 4 fetch call sites that previously had no timeout (saveDelete.js GET+POST, appDataStore.js deletePreset() POST, appDataStore.js saveControllerMetadata() GET+POST). Unreachable controllers are now skipped after 5 seconds instead of hanging indefinitely.
0575f67 — fix: parallelize startup fetches and fix makeID undefined controller
Startup performance: Removed all artificial delays (INIT_DELAYS now all zero) and replaced the sequential store initialization loop in initializeStores.js with Promise.all() — info, color, config, and appData stores now fetch in parallel on startup.
Undefined controller IDs: makeID() in tools.js was reading infoData.data.deviceid (flat path) but normalizeInfoData() in infoDataStore.js had been refactored to use the nested structure data.device.deviceid. The mismatch caused all generated IDs to contain "undefined". Fixed with optional chaining and fallback: data?.device?.deviceid ?? data?.deviceid.
0484231 — fix: show CT slider for all color modes with white channel
showCtSlider in HsvSection.vue was only returning true for "RGBWW", hiding the color temperature slider for "RGBWWCW" and "RGBCW" modes. Fixed to include all three modes that have a white channel.
