### PR TITLE
chore: align quasar build target to node24

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -56,7 +56,7 @@ export default configure((/* ctx */) => {
       cssMinify: 'esbuild',
       target: {
         browser: ["es2020"],
-        node: "node20",
+        node: "node24",
       },
       useFilenameHashes: false,
       vueRouterMode: "hash",


### PR DESCRIPTION
Body:
Summary
This PR updates the Quasar build target node version from node20 to node24 to align with current project and workflow direction.

Why
Tooling and workflow updates are moving to Node 24, and this keeps build target declarations consistent with that baseline.

What changed

Updated Quasar build target node setting to node24.
No other build flags or runtime behavior were modified.
Impact

Reduces version drift between config, CI, and expected local environment.
Keeps future dependency updates simpler by maintaining a single node baseline.
Testing

Verified branch contains only the node target alignment commit.
Change is configuration-only and low risk.