### PR TITLE
refactor: simplify config field save bindings in settings cards

### DIFF
--- a/src/ToDo.md
+++ b/src/ToDo.md
@@ -1,1 +1,8 @@
+# Webapp Refactor TODO
+
+- [ ] Avoid direct store mutation in UI components and route all changes through store update APIs (example: `HostnameCard` writes directly to `configData.data.general.device_name`).
+- [ ] Replace repeated inline width and layout styles with shared utility classes or card-level CSS tokens.
+- [ ] Refactor `NetworkInit` step indicator markup to be data-driven from a step definition array.
+- [ ] Standardize import aliases (`src/...` vs `components/...`) and enforce with ESLint rule/config.
+- [ ] Gate debug `console.*` calls behind an environment-aware logger and remove noisy production logs.
 

--- a/src/components/cards/MqttSettingsCard.vue
+++ b/src/components/cards/MqttSettingsCard.vue
@@ -180,6 +180,7 @@
 <script>
 import { ref } from "vue";
 import { configDataStore } from "src/stores/configDataStore";
+import { useConfigBinding } from "src/composables/useConfigDataBindings";
 import MyCard from "src/components/myCard.vue";
 
 export default {
@@ -190,104 +191,116 @@ export default {
     const configData = configDataStore();
     const isPwd = ref(true);
 
-    const mqttEnabled = ref(configData.data.network.mqtt.enabled);
-    const mqttServer = ref(configData.data.network.mqtt.server);
-    const mqttPort = ref(configData.data.network.mqtt.port);
-    const mqttTopicBase = ref(configData.data.network.mqtt.topic_base);
-    const mqttUsername = ref(configData.data.network.mqtt.username);
-    const mqttPassword = ref(configData.data.network.mqtt.password);
-
-    // Home Assistant settings
-    const haEnabled = ref(configData.data.network.mqtt.homeassistant.enable);
-    const haDiscoveryPrefix = ref(
-      configData.data.network.mqtt.homeassistant.discovery_prefix,
-    );
-    const haNodeId = ref(
-      configData.data.network.mqtt.homeassistant.node_id ||
-        configData.data.general.device_name,
+    const { model: mqttEnabled, save: updateMqttEnabled } = useConfigBinding(
+      configData,
+      "network.mqtt.enabled",
+      {
+        fallback: false,
+        persist: true,
+      },
     );
 
-    // Sync settings
-    const clockMasterEnabled = ref(configData.data.sync.clock_master_enabled);
-    const cmdMasterEnabled = ref(configData.data.sync.cmd_master_enabled);
-    const colorMasterEnabled = ref(configData.data.sync.color_master_enabled);
-    const clockSlaveEnabled = ref(configData.data.sync.clock_slave_enabled);
-    const cmdSlaveEnabled = ref(configData.data.sync.cmd_slave_enabled);
-    const colorSlaveEnabled = ref(configData.data.sync.color_slave_enabled);
+    const { model: mqttServer, save: updateMqttServer } = useConfigBinding(
+      configData,
+      "network.mqtt.server",
+      {
+        fallback: "",
+        persist: true,
+      },
+    );
 
-    const updateMqttEnabled = (value) => {
-      configData.updateData("network.mqtt.enabled", value, true);
-    };
+    const { model: mqttPort, save: updateMqttPort } = useConfigBinding(
+      configData,
+      "network.mqtt.port",
+      {
+        fallback: 1883,
+        persist: true,
+      },
+    );
 
-    const updateMqttServer = () => {
-      configData.updateData("network.mqtt.server", mqttServer.value, true);
-    };
+    const { model: mqttTopicBase, save: updateMqttTopicBase } =
+      useConfigBinding(configData, "network.mqtt.topic_base", {
+        fallback: "",
+        persist: true,
+      });
 
-    const updateMqttPort = () => {
-      configData.updateData("network.mqtt.port", mqttPort.value, true);
-    };
+    const { model: mqttUsername, save: updateMqttUsername } = useConfigBinding(
+      configData,
+      "network.mqtt.username",
+      {
+        fallback: "",
+        persist: true,
+      },
+    );
 
-    const updateMqttTopicBase = () => {
-      configData.updateData(
-        "network.mqtt.topic_base",
-        mqttTopicBase.value,
-        true,
-      );
-    };
+    const { model: mqttPassword, save: updateMqttPassword } = useConfigBinding(
+      configData,
+      "network.mqtt.password",
+      {
+        fallback: "",
+        persist: true,
+      },
+    );
 
-    const updateMqttUsername = () => {
-      configData.updateData("network.mqtt.username", mqttUsername.value, true);
-    };
+    const { model: haEnabled, save: updateHaEnabled } = useConfigBinding(
+      configData,
+      "network.mqtt.homeassistant.enable",
+      {
+        fallback: false,
+        persist: true,
+      },
+    );
 
-    const updateMqttPassword = () => {
-      configData.updateData("network.mqtt.password", mqttPassword.value, true);
-    };
+    const { model: haDiscoveryPrefix, save: updateHaDiscoveryPrefix } =
+      useConfigBinding(configData, "network.mqtt.homeassistant.discovery_prefix", {
+        fallback: "",
+        persist: true,
+      });
 
-    // Home Assistant update functions
-    const updateHaEnabled = (value) => {
-      configData.updateData("network.mqtt.homeassistant.enable", value, true);
-    };
+    const { model: haNodeId, save: updateHaNodeId } = useConfigBinding(
+      configData,
+      "network.mqtt.homeassistant.node_id",
+      {
+        fallback: configData.data?.general?.device_name || "",
+        persist: true,
+      },
+    );
 
-    const updateHaDiscoveryPrefix = () => {
-      configData.updateData(
-        "network.mqtt.homeassistant.discovery_prefix",
-        haDiscoveryPrefix.value,
-        true,
-      );
-    };
+    const { model: clockMasterEnabled, save: updateClockMasterEnabled } =
+      useConfigBinding(configData, "sync.clock_master_enabled", {
+        fallback: false,
+        persist: true,
+      });
 
-    const updateHaNodeId = () => {
-      configData.updateData(
-        "network.mqtt.homeassistant.node_id",
-        haNodeId.value,
-        true,
-      );
-    };
+    const { model: cmdMasterEnabled, save: updateCmdMasterEnabled } =
+      useConfigBinding(configData, "sync.cmd_master_enabled", {
+        fallback: false,
+        persist: true,
+      });
 
-    // Sync update functions
-    const updateClockMasterEnabled = (value) => {
-      configData.updateData("sync.clock_master_enabled", value, true);
-    };
+    const { model: colorMasterEnabled, save: updateColorMasterEnabled } =
+      useConfigBinding(configData, "sync.color_master_enabled", {
+        fallback: false,
+        persist: true,
+      });
 
-    const updateCmdMasterEnabled = (value) => {
-      configData.updateData("sync.cmd_master_enabled", value, true);
-    };
+    const { model: clockSlaveEnabled, save: updateClockSlaveEnabled } =
+      useConfigBinding(configData, "sync.clock_slave_enabled", {
+        fallback: false,
+        persist: true,
+      });
 
-    const updateColorMasterEnabled = (value) => {
-      configData.updateData("sync.color_master_enabled", value, true);
-    };
+    const { model: cmdSlaveEnabled, save: updateCmdSlaveEnabled } =
+      useConfigBinding(configData, "sync.cmd_slave_enabled", {
+        fallback: false,
+        persist: true,
+      });
 
-    const updateClockSlaveEnabled = (value) => {
-      configData.updateData("sync.clock_slave_enabled", value, true);
-    };
-
-    const updateCmdSlaveEnabled = (value) => {
-      configData.updateData("sync.cmd_slave_enabled", value, true);
-    };
-
-    const updateColorSlaveEnabled = (value) => {
-      configData.updateData("sync.color_slave_enabled", value, true);
-    };
+    const { model: colorSlaveEnabled, save: updateColorSlaveEnabled } =
+      useConfigBinding(configData, "sync.color_slave_enabled", {
+        fallback: false,
+        persist: true,
+      });
 
     return {
       configData,

--- a/src/components/cards/RsyslogSettingsCard.vue
+++ b/src/components/cards/RsyslogSettingsCard.vue
@@ -36,8 +36,8 @@
 </template>
 
 <script>
-import { ref, watch } from "vue";
 import { configDataStore } from "src/stores/configDataStore";
+import { useConfigBinding } from "src/composables/useConfigDataBindings";
 import MyCard from "src/components/myCard.vue";
 
 export default {
@@ -48,33 +48,36 @@ export default {
   setup() {
     const configData = configDataStore();
 
-    const enabled = ref(configData.data?.network?.rsyslog?.enabled ?? false);
-    const host = ref(configData.data?.network?.rsyslog?.host ?? "");
-    const port = ref(configData.data?.network?.rsyslog?.port ?? 514);
-
-    watch(
-      () => configData.data?.network?.rsyslog,
-      (newValue) => {
-        enabled.value = newValue?.enabled ?? false;
-        host.value = newValue?.host ?? "";
-        port.value = newValue?.port ?? 514;
+    const { model: enabled, save: updateEnabled } = useConfigBinding(
+      configData,
+      "network.rsyslog.enabled",
+      {
+        fallback: false,
+        persist: true,
       },
-      { deep: true },
     );
 
-    const updateEnabled = (value) => {
-      configData.updateData("network.rsyslog.enabled", value, true);
-    };
+    const { model: host, save: updateHost } = useConfigBinding(
+      configData,
+      "network.rsyslog.host",
+      {
+        fallback: "",
+        persist: true,
+      },
+    );
 
-    const updateHost = () => {
-      configData.updateData("network.rsyslog.host", host.value, true);
-    };
-
-    const updatePort = () => {
-      const normalizedPort = Number.parseInt(port.value, 10);
-      port.value = Number.isFinite(normalizedPort) ? normalizedPort : 514;
-      configData.updateData("network.rsyslog.port", port.value, true);
-    };
+    const { model: port, save: updatePort } = useConfigBinding(
+      configData,
+      "network.rsyslog.port",
+      {
+        fallback: 514,
+        persist: true,
+        normalize: (value) => {
+          const normalizedPort = Number.parseInt(value, 10);
+          return Number.isFinite(normalizedPort) ? normalizedPort : 514;
+        },
+      },
+    );
 
     return {
       enabled,

--- a/src/components/cards/TelemetryCard.vue
+++ b/src/components/cards/TelemetryCard.vue
@@ -99,6 +99,7 @@
 <script>
 import { ref, computed } from "vue";
 import { configDataStore } from "src/stores/configDataStore";
+import { useConfigBinding } from "src/composables/useConfigDataBindings";
 import MyCard from "components/myCard.vue";
 import { telemetryDataColumns, telemetryDataRows } from "src/stores/telemetryData.js";
 
@@ -114,11 +115,45 @@ export default {
       { label: "Off", value: "OFF" },
     ];
 
-    const statsValue = ref(configData.data?.telemetry?.statsEnabled === "ON" ? "ON" : "OFF");
-    const logValue = ref(configData.data?.telemetry?.logEnabled === "ON" ? "ON" : "OFF");
-    const urlValue = ref(configData.data?.telemetry?.url || configData.data?.debug?.server || "");
-    const userValue = ref(configData.data?.telemetry?.user || configData.data?.network?.mqtt?.username || "");
-    const passwordValue = ref(configData.data?.telemetry?.password || configData.data?.network?.mqtt?.password || "");
+    const { model: statsValue, save: updateStats } = useConfigBinding(
+      configData,
+      "telemetry.statsEnabled",
+      {
+        fallback: configData.data?.telemetry?.statsEnabled === "ON" ? "ON" : "OFF",
+      },
+    );
+
+    const { model: logValue, save: updateLog } = useConfigBinding(
+      configData,
+      "telemetry.logEnabled",
+      {
+        fallback: configData.data?.telemetry?.logEnabled === "ON" ? "ON" : "OFF",
+      },
+    );
+
+    const { model: urlValue, save: updateUrl } = useConfigBinding(
+      configData,
+      "telemetry.url",
+      {
+        fallback: configData.data?.debug?.server || "",
+      },
+    );
+
+    const { model: userValue, save: updateUser } = useConfigBinding(
+      configData,
+      "telemetry.user",
+      {
+        fallback: configData.data?.network?.mqtt?.username || "",
+      },
+    );
+
+    const { model: passwordValue, save: updatePassword } = useConfigBinding(
+      configData,
+      "telemetry.password",
+      {
+        fallback: configData.data?.network?.mqtt?.password || "",
+      },
+    );
 
     const showDetails = ref(false);
 
@@ -126,26 +161,6 @@ export default {
 
     const toggleDetails = () => {
       showDetails.value = !showDetails.value;
-    };
-
-    const updateStats = (value) => {
-      configData.updateData("telemetry.statsEnabled", value);
-    };
-
-    const updateLog = (value) => {
-      configData.updateData("telemetry.logEnabled", value);
-    };
-
-    const updateUrl = () => {
-      configData.updateData("telemetry.url", urlValue.value);
-    };
-
-    const updateUser = () => {
-      configData.updateData("telemetry.user", userValue.value);
-    };
-
-    const updatePassword = () => {
-      configData.updateData("telemetry.password", passwordValue.value);
     };
 
     return {

--- a/src/composables/useConfigDataBindings.js
+++ b/src/composables/useConfigDataBindings.js
@@ -1,0 +1,45 @@
+import { ref, watch } from "vue";
+
+function getPathValue(source, path, fallback) {
+  if (!source || !path) {
+    return fallback;
+  }
+
+  const result = path.split(".").reduce((value, key) => {
+    if (value == null) {
+      return undefined;
+    }
+
+    return value[key];
+  }, source);
+
+  return result === undefined ? fallback : result;
+}
+
+export function useConfigBinding(configData, path, options = {}) {
+  const {
+    fallback = "",
+    persist = false,
+    normalize,
+  } = options;
+
+  const model = ref(getPathValue(configData.data, path, fallback));
+
+  watch(
+    () => getPathValue(configData.data, path, fallback),
+    (nextValue) => {
+      model.value = nextValue;
+    },
+  );
+
+  const save = (nextValue = model.value) => {
+    const normalizedValue = normalize ? normalize(nextValue) : nextValue;
+    model.value = normalizedValue;
+    configData.updateData(path, normalizedValue, persist);
+  };
+
+  return {
+    model,
+    save,
+  };
+}


### PR DESCRIPTION
Summary
This PR introduces a reusable config binding composable and refactors repeated blur-save boilerplate in selected settings cards.

Why
Several settings cards repeat the same local ref, watcher, and update function patterns for config fields, which increases maintenance overhead and inconsistency risk.

What changed

Added a shared composable for binding config paths to local models with save behavior.
Refactored three settings cards to use the shared composable.
Preserved existing blur-save and persist semantics.
Added follow-up refactor items to the existing todo document for remaining non-scoped findings.
Impact

Reduces duplicate code in settings forms.
Standardizes field update patterns.
Makes future settings cards faster to implement and easier to review.
Testing

Verified branch scope is limited to composable introduction, targeted card refactors, and todo updates.
No intentional UI behavior changes beyond internal simplification.
Notes
This PR is a first refactor slice and does not attempt full codebase migration in one step.