### PR TITLE
fix(firmware): use nested infoDataStore format in firmware select dialog

### DIFF
--- a/src/ToDo.md
+++ b/src/ToDo.md
@@ -9,4 +9,5 @@
 - [x] color temp slider should only be shown if the color model is RGBWW - not for any other color model
 - [x] the central interaction pages should generally be hanging from the top of the page and use 80% of the page hight
 - Question: is there a way to have a ui where the user can tear off the various cards and place them on the window? 
- 
+- [x] firmware update dialog does not yet use the new infoDataStore format and therefore does not correctly select the build type
+- [ ] on wide viewports, show the system information card on the left and the other cards to its right in a two-column layout

--- a/src/components/Dialogs/firmwareSelectDialog.vue
+++ b/src/components/Dialogs/firmwareSelectDialog.vue
@@ -28,15 +28,15 @@
               </tr>
               <tr>
                 <td class="label">Build type:</td>
-                <td>{{ currentInfo.build_type }}</td>
+                <td>{{ currentInfo.app?.build_type }}</td>
               </tr>
               <tr>
                 <td class="label">Version:</td>
-                <td>{{ currentInfo.git_version }}</td>
+                <td>{{ currentInfo.app?.git_version }}</td>
               </tr>
               <tr>
                 <td class="label">Webapp version:</td>
-                <td>{{ currentInfo.webapp_version }}</td>
+                <td>{{ currentInfo.app?.webapp_version }}</td>
               </tr>
             </tbody>
           </table>
@@ -182,7 +182,7 @@ export default {
 
     // Selection state - initialize with current values
     const selectedBranch = ref(props.currentInfo.branch || "stable");
-    const selectedType = ref(props.currentInfo.build_type || "release");
+    const selectedType = ref(props.currentInfo.app?.build_type || "release");
     const selectedVersionId = ref(null);
 
     // Color helper for branches - defined before it's used


### PR DESCRIPTION
Fixes the firmware update dialog to read \`build_type\`, \`git_version\`, and \`webapp_version\` from \`currentInfo.app.*\` instead of the flat legacy structure, matching the normalized \`infoDataStore\` format introduced in V5.1.

Closes ToDo item 12.