### PR TITLE
feat(layout): two-column system settings on wide viewports

### DIFF
--- a/src/ToDo.md
+++ b/src/ToDo.md
@@ -8,5 +8,6 @@
 - [x] the buttons for presets and scenes in the favorites card should be more elegant, more user friendly, more recognizable. They should invite the user to press them and ituitively show that this is a light setting. The button should show the name and the color / the five color swatch for raw presets. I am not sure that the scrolling list is ideal, maybe a tabbed control for all groups would be better (only for those that actually have favorite presets or scenes, of course )
 - [x] color temp slider should only be shown if the color model is RGBWW - not for any other color model
 - [x] the central interaction pages should generally be hanging from the top of the page and use 80% of the page hight
-- Question: is there a way to have a ui where the user can tear off the various cards and place them on the window? 
- 
+- Question: is there a way to have a ui where the user can tear off the various cards and place them on the window?
+- [ ] firmware update dialog does not yet use the new infoDataStore format and therefore does not correctly select the build type
+- [ ] on wide viewports, show the system information card on the left and the other cards to its right in a two-column layout

--- a/src/pages/SystemSettings.vue
+++ b/src/pages/SystemSettings.vue
@@ -1,12 +1,16 @@
 <template>
-  <div>
-    <InformationCard :collapsed="false" />
-    <FirmwareUpdateCard />
-    <HostnameCard />
-    <ControllerConfigCard />
-    <SaveRestoreConfig />
-    <DebugFunctionCard v-if="infoData.data?.app?.build_type === 'debug'" />
-    <LogViewerCard v-if="infoData.data?.app?.build_type === 'debug'" />
+  <div class="system-settings-layout">
+    <div class="info-column">
+      <InformationCard :collapsed="false" />
+    </div>
+    <div class="cards-column">
+      <FirmwareUpdateCard />
+      <HostnameCard />
+      <ControllerConfigCard />
+      <SaveRestoreConfig />
+      <DebugFunctionCard v-if="infoData.data?.app?.build_type === 'debug'" />
+      <LogViewerCard v-if="infoData.data?.app?.build_type === 'debug'" />
+    </div>
   </div>
 </template>
 
@@ -39,3 +43,35 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.system-settings-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.info-column,
+.cards-column {
+  width: 100%;
+}
+
+@media (min-width: 900px) {
+  .system-settings-layout {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .info-column {
+    flex: 0 0 340px;
+    position: sticky;
+    top: 0;
+  }
+
+  .cards-column {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+}
+</style>


### PR DESCRIPTION
On viewports ≥900px, \`SystemSettings\` now uses a two-column flex layout: \`InformationCard\` is pinned to the left (340px, sticky) and all other cards fill the right column. On narrow screens the layout falls back to the existing single-column stack.

Closes ToDo item 11.